### PR TITLE
docs: add AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS
+
+## Retrieval Order
+
+1. Start with this file at the repository root.
+2. For any file you touch, also read `AGENTS.md` files in ancestor directories.
+3. More deeply nested instructions override parent scopes.
+
+## Task Intake Template
+
+### Summary
+
+- <short bullet list of changes>
+
+### Testing
+
+- <command> (result)
+
+## Repository Guidelines
+
+- **Parser-first**: new features expose at least one intent or noun and update lexicon assets and tests.
+- **Echoes over flags**: emit Echoes per schema; avoid ad hoc booleans.
+- **Deterministic code only**: seed any RNG through state.
+- **Respect file ownership**: do not modify `legacy/` without task notes.
+- **TS strict, ESLint, Prettier**: match existing patterns.
+- **Small PRs**: explain trade-offs and provide diffs, not blobs.
+- **Tests required**: add/modify tests for state transitions and parser recognition (positive/negative).
+- **Public API changes**: update `CHANGELOG.md` and provide migration notes.
+- **Missing context**: state assumptions and add a stub in `docs/` with open questions.

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,0 +1,8 @@
+# Open Questions
+
+- Schema for `VerbDef` and `NounDef` `.tres` assets
+- Expected directory structure for new lexicon resources (`godot/data/verbs`, `godot/data/nouns`)
+- Beat JSON schema and scheduler behavior
+- Location and format of `ParserService.gd` tests
+
+Additional context or specifications are required before implementing the verb/noun conversions, beat porting, and scheduler tests.


### PR DESCRIPTION
## Summary
- establish root AGENTS.md with retrieval order, task template, and contributor guidelines
- update open questions doc to reflect remaining schema and test gaps

## Testing
- `npx prettier AGENTS.md docs/OPEN_QUESTIONS.md --write`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be6f509cfc8323882dd3bb26dc77f4